### PR TITLE
Fix missing log directory

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,9 @@
 import logging
+import os
 from datetime import datetime
 
 def setup_logging():
+    os.makedirs("logs", exist_ok=True)
     log_filename = f"logs/mega_sena_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
     logging.basicConfig(
         filename=log_filename,


### PR DESCRIPTION
## Summary
- prevent logging errors by ensuring `logs/` exists

## Testing
- `python -m py_compile utils.py cli.py analyzer.py validator.py downloader.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6849bb7205e083269b112c84eb97cd03